### PR TITLE
Adding Coin check balance and claim functionality to CLI

### DIFF
--- a/AntSharesDaemon/Shell/Coins.cs
+++ b/AntSharesDaemon/Shell/Coins.cs
@@ -1,0 +1,109 @@
+using AntShares.Core;
+using System;
+using System.Linq;
+using AntShares.Wallets;
+using AntShares.Network;
+
+namespace AntShares.Shell
+{
+
+    public class Coins
+    {
+        private Wallet current_wallet;
+        private LocalNode local_node;
+
+        public Coins(Wallet wallet, LocalNode node)
+        {
+            current_wallet = wallet;
+            local_node = node;
+        }
+
+        public Fixed8 UnavailableBonus()
+        {
+            uint height = Blockchain.Default.Height + 1;
+            return Blockchain.CalculateBonus(current_wallet.FindUnspentCoins().Where(p => p.Output.AssetId.Equals(Blockchain.SystemShare.Hash)).Select(p => p.Reference), height);
+        }
+
+
+        public Fixed8 AvailableBonus()
+        {
+            return Blockchain.CalculateBonus(current_wallet.GetUnclaimedCoins().Select(p => p.Reference));
+        }
+
+
+        public bool Claim()
+        {
+
+            if (this.AvailableBonus() == Fixed8.Zero)
+            {
+                Console.WriteLine($"no coins to claim");
+                return true;
+            }
+
+            CoinReference[] claims = current_wallet.GetUnclaimedCoins().Select(p => p.Reference).ToArray();
+            if (claims.Length == 0) return false;
+
+
+            ClaimTransaction tx = new ClaimTransaction
+            {
+                Claims = claims,
+                Attributes = new TransactionAttribute[0],
+                Inputs = new CoinReference[0],
+                Outputs = new[]
+                {
+                    new TransactionOutput
+                    {
+                        AssetId = Blockchain.SystemCoin.Hash,
+                        Value = Blockchain.CalculateBonus(claims),
+                        ScriptHash = current_wallet.GetChangeAddress()
+                    }
+                }
+
+            };
+
+            Console.WriteLine($"Will sign tx: {tx}");
+            bool result = SignTransaction(tx);
+
+            return result;
+        }
+
+
+        private bool SignTransaction(Transaction tx)
+        {
+            if (tx == null)
+            {
+                Console.WriteLine($"no transaction specified");
+                return false;
+            }
+            SignatureContext context;
+
+            try
+            {
+                context = new SignatureContext(tx);
+            }
+            catch (InvalidOperationException)
+            {
+                Console.WriteLine($"unsynchronized block");
+
+                return false;
+            }
+
+            current_wallet.Sign(context);
+
+            if (context.Completed)
+            {
+                context.Verifiable.Scripts = context.GetScripts();
+                current_wallet.SaveTransaction(tx);
+                local_node.Relay(tx);
+                Console.WriteLine($"Transaction Suceeded: {tx.Hash.ToString()}");
+                return true;
+            }
+            else
+            {
+                Console.WriteLine($"Incomplete Signature: {context.ToString()}");
+            }
+
+            return false;
+        }
+    }
+}

--- a/AntSharesDaemon/Shell/Coins.cs
+++ b/AntSharesDaemon/Shell/Coins.cs
@@ -21,7 +21,18 @@ namespace AntShares.Shell
         public Fixed8 UnavailableBonus()
         {
             uint height = Blockchain.Default.Height + 1;
-            return Blockchain.CalculateBonus(current_wallet.FindUnspentCoins().Where(p => p.Output.AssetId.Equals(Blockchain.SystemShare.Hash)).Select(p => p.Reference), height);
+            Fixed8 unavailable;
+
+            try
+            {
+                unavailable = Blockchain.CalculateBonus(current_wallet.FindUnspentCoins().Where(p => p.Output.AssetId.Equals(Blockchain.SystemShare.Hash)).Select(p => p.Reference), height);
+            }
+            catch (Exception)
+            {
+                unavailable = Fixed8.Zero;
+            }
+
+            return unavailable;
         }
 
 

--- a/AntSharesDaemon/Shell/MainService.cs
+++ b/AntSharesDaemon/Shell/MainService.cs
@@ -14,6 +14,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
+using AntShares.Shell;
 
 namespace AntShares.Shell
 {
@@ -60,6 +61,8 @@ namespace AntShares.Shell
                     return OnImportCommand(args);
                 case "list":
                     return OnListCommand(args);
+                case "coin":
+                    return OnCoinCommand(args);
                 case "open":
                     return OnOpenCommand(args);
                 case "rebuild":
@@ -267,6 +270,8 @@ namespace AntShares.Shell
                 "\tlist address\n" +
                 "\tlist asset\n" +
                 "\tlist key\n" +
+                "\tcoin check\n" +
+                "\tcoin claim\n" +
                 "\tcreate address [n=1]\n" +
                 "\timport key <wif|path>\n" +
                 "\texport key [address] [path]\n" +
@@ -343,6 +348,31 @@ namespace AntShares.Shell
                     return OnListKeyCommand(args);
                 default:
                     return base.OnCommand(args);
+            }
+        }
+
+        private bool OnCoinCommand(string[] args)
+        {
+            if (Program.Wallet == null)
+            {
+                Console.WriteLine($"Please open a wallet");
+                return true;
+            }
+
+            Coins coins = new Coins(Program.Wallet, LocalNode);
+
+            switch (args[1].ToLower())
+            {
+                case "check":
+                    Console.WriteLine($"unavailable: {coins.UnavailableBonus().ToString()}");
+                    Console.WriteLine($"  available: {coins.AvailableBonus().ToString()}");
+                    return true;
+                case "claim":
+                    coins.Claim();
+                    return true;
+
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
This PR adds the following features to the CLI:
- ability to list unavailable and unclaimed ANC. 
- ability to claim unclaimed ANC

![screen shot 2017-07-03 at 7 26 25 pm](https://user-images.githubusercontent.com/192884/27830399-e64f4852-608b-11e7-975a-36ab60274eb6.png)
![screen shot 2017-07-03 at 7 29 00 pm](https://user-images.githubusercontent.com/192884/27830398-e64f42ee-608b-11e7-9c88-b64df28f4f37.png)
